### PR TITLE
Cve 2019 3498

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Django==2.1.3
+Django==2.1.5
 django-enumchoicefield==1.0.2


### PR DESCRIPTION
upgrading to Django 2.1.5 will get rid of the vulnerability alert GitHub keeps annoying us about